### PR TITLE
Minor Improvements

### DIFF
--- a/ReeeedSample/Shared/ContentView.swift
+++ b/ReeeedSample/Shared/ContentView.swift
@@ -20,6 +20,7 @@ struct ContentView: View {
                 ArticleButton(title: "Test Article (Verge)", url: "https://www.theverge.com/2023/9/3/23857664/california-forever-tech-billionaire-secret-city")
                 ArticleButton(title: "Test Article (image at top)", url: "https://9to5mac.com/2023/09/08/apple-iphone-15-event-what-to-expect/")
                 ArticleButton(title: "Unextractable Page", url: "https://google.com")
+                ArticleButton(title: "Extract ISO Latin", url: "https://www.politicargentina.com/notas/202411/62138-are-you-pistarini-el-comico-posteo-de-la-afa-tras-el-episodio-entre-dillom-y-el-tuitero-libertario.html")
             }
             .frame(minWidth: 200)
         }

--- a/Sources/Reeeed/Reeeed.swift
+++ b/Sources/Reeeed/Reeeed.swift
@@ -63,14 +63,14 @@ public enum Reeeed {
     }
 
     public static func fetchAndExtractContent(fromURL url: URL, theme: ReaderTheme = .init(), extractor: Extractor = .mercury) async throws -> FetchAndExtractionResult {
-        DispatchQueue.main.async { Reeeed.warmup() }
-        
+        DispatchQueue.main.async { Reeeed.warmup(extractor: extractor) }
+
         let (data, response) = try await URLSession.shared.data(from: url)
-        guard let html = String(data: data, encoding: .utf8) else {
+        guard let html = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .isoLatin1) else {
             throw ExtractionError.DataIsNotString
         }
         let baseURL = response.url ?? url
-        let content = try await Reeeed.extractArticleContent(url: baseURL, html: html)
+        let content = try await Reeeed.extractArticleContent(url: baseURL, html: html, extractor: extractor)
         guard let extractedHTML = content.content else {
             throw ExtractionError.MissingExtractionData
         }


### PR DESCRIPTION
I updated the default `fetchAndExtractContent` method to reuse the same extractor for `Reeeed.warmup` & `Reeeed.extractArticleContent`.

I also added a minor update to get the article string when the article failed using .utf8 encoding. To test this, I added a new item to the example list, which previously failed and now displays correctly